### PR TITLE
chore: use scip-go instead of lsif-go for precise indexing in CI

### DIFF
--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -1,4 +1,4 @@
-name: LSIF
+name: SCIP
 on:
   - push
 jobs:
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Generate LSIF data
-        uses: sourcegraph/lsif-go-action@master
+      - name: Generate SCIP data
+        uses: sourcegraph/scip-go-action@master
         with:
           verbose: "true"
-      - name: Upload LSIF data
+      - name: Upload SCIP data
         uses: sourcegraph/lsif-upload-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Does what it says on the tin
## Test plan
scip-go GHA passes

[_Created by Sourcegraph batch change `Strum355/lsif-go_to_scip-go`._](https://sourcegraph.sourcegraph.com/users/Strum355/batch-changes/lsif-go_to_scip-go)